### PR TITLE
Fix mismatched types

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn is_head(line: &str) -> bool {
 }
 #[cfg(not(windows))]
 fn canonicalize(path: &String) -> String {
-    fs::canonicalize(path).unwrap().to_str().unwrap()
+    fs::canonicalize(path).unwrap().to_str().unwrap().to_string()
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Like the code for Windows, we want to avoid build failures by adding to_string() for non-Windows code.