### PR TITLE
Add test for code block with tildes

### DIFF
--- a/test/mdctags.bats
+++ b/test/mdctags.bats
@@ -114,7 +114,6 @@ __EXPECT__
 }
 
 @test "Code blocks with tildes are ignored" {
-  skip "Currently, this command corresponds to a code block with tilde symbols."
   local markdown_file tags_file expect_file
   markdown_file=$(get_markdown_file)
   tags_file=$(get_tags_file)


### PR DESCRIPTION
After we add code blocks with tildes, we should add test too. #5 

~~~
~/mdctags.rs$ bats test
 ✓ If there are no arguments, it terminates abnormally
 ✓ If the argument is given and the file does not exist, it terminates abnormally
 ✓ If an empty file is given, only exclamation mark lines will be output
 ✓ If the level of the headline is 7 or higher, it ends normally
 ✓ If the level is insufficient, make the appropriate heading the parent heading
 ✓ Code blocks with backticks are ignored
 ✓ Code blocks with tildes are ignored
 ✓ Normal exit
 ✓ If the previous level is larger, it ends normally
 ✓ If the previous level is more larger, it ends normally
 ✓ If the previous level is same, it ends normally

11 tests, 0 failures
~~~