### PR TITLE
Add indented fences

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,14 +45,18 @@ fn canonicalize(path: &String) -> String {
 }
 
 fn update_in_code(line: &str, in_code: &mut CodeBlockKind) {
-    if line.starts_with("```") {
+    lazy_static! {
+        static ref RE_BACKTICKS: Regex = Regex::new("^ *```").unwrap();
+        static ref RE_TILDES: Regex = Regex::new("^ *~~~").unwrap();
+    }
+    if RE_BACKTICKS.is_match(line) {
         *in_code = match in_code {
             CodeBlockKind::NotInCodeBlock => CodeBlockKind::Backticks,
             CodeBlockKind::Backticks => CodeBlockKind::NotInCodeBlock,
             _ => panic!(),
         }
     }
-    if line.starts_with("~~~") {
+    if RE_TILDES.is_match(line) {
         *in_code = match in_code {
             CodeBlockKind::NotInCodeBlock => CodeBlockKind::Tildes,
             CodeBlockKind::Tildes => CodeBlockKind::NotInCodeBlock,

--- a/test/mdctags.bats
+++ b/test/mdctags.bats
@@ -113,6 +113,33 @@ __EXPECT__
   diff -u "$tags_file" "$expect_file"
 }
 
+@test "Fences with backticks can be indented" {
+  local markdown_file tags_file expect_file
+  markdown_file=$(get_markdown_file)
+  tags_file=$(get_tags_file)
+  expect_file=$(get_expect_file)
+
+  cat <<'__MARKDOWN__' >"$markdown_file"
+# hd1a
+  ```
+aaa
+  aaa
+aaa
+# in code block
+  ```
+# hd1b
+__MARKDOWN__
+
+  run_ok "$markdown_file" "$tags_file"
+
+  cat <<'__EXPECT__' >"$expect_file"
+hd1a<tab>/a.md<tab>/^# hd1a$/;"<tab>a<tab>line:1<tab>
+hd1b<tab>/a.md<tab>/^# hd1b$/;"<tab>a<tab>line:8<tab>
+__EXPECT__
+
+  diff -u "$tags_file" "$expect_file"
+}
+
 @test "Code blocks with tildes are ignored" {
   local markdown_file tags_file expect_file
   markdown_file=$(get_markdown_file)
@@ -132,6 +159,33 @@ __MARKDOWN__
   cat <<'__EXPECT__' >"$expect_file"
 hd1a<tab>/a.md<tab>/^# hd1a$/;"<tab>a<tab>line:1<tab>
 hd1b<tab>/a.md<tab>/^# hd1b$/;"<tab>a<tab>line:5<tab>
+__EXPECT__
+
+  diff -u "$tags_file" "$expect_file"
+}
+
+@test "Fences with tildes can be indented" {
+  local markdown_file tags_file expect_file
+  markdown_file=$(get_markdown_file)
+  tags_file=$(get_tags_file)
+  expect_file=$(get_expect_file)
+
+  cat <<'__MARKDOWN__' >"$markdown_file"
+# hd1a
+  ~~~
+aaa
+  aaa
+aaa
+# in code block
+  ~~~
+# hd1b
+__MARKDOWN__
+
+  run_ok "$markdown_file" "$tags_file"
+
+  cat <<'__EXPECT__' >"$expect_file"
+hd1a<tab>/a.md<tab>/^# hd1a$/;"<tab>a<tab>line:1<tab>
+hd1b<tab>/a.md<tab>/^# hd1b$/;"<tab>a<tab>line:8<tab>
 __EXPECT__
 
   diff -u "$tags_file" "$expect_file"


### PR DESCRIPTION
In rare cases, Markdown contains a code block with a leading space in it.

~~~
  ```
aaa
  aaa
aaa
  ```
~~~

This is a proper code block, as defined by the following URL: 
https://spec.commonmark.org/0.29/#example-101

If you merge this pull request, you can create ctags to the code block even if it contains indentation.